### PR TITLE
Add try-catch for error handling in getAvailableSegments method

### DIFF
--- a/src/ts/CmcdIntegration.ts
+++ b/src/ts/CmcdIntegration.ts
@@ -315,12 +315,16 @@ export class CmcdIntegration {
     }
 
     if (this.currentVideoQuality) {
-      const allSegments = this.player.getAvailableSegments();
-      for (const mimeType in allSegments) {
-        if (mimeType.startsWith('video/')) {
-          const segments = allSegments[mimeType][this.currentVideoQuality.id];
-          data = data.concat(this.getNextObjectAndObjectDurationCmcdData(segments, request.url));
+      try {
+        const allSegments = this.player.getAvailableSegments();
+        for (const mimeType in allSegments) {
+          if (mimeType.startsWith('video/')) {
+            const segments = allSegments[mimeType][this.currentVideoQuality.id];
+            data = data.concat(this.getNextObjectAndObjectDurationCmcdData(segments, request.url));
+          }
         }
+      } catch (error) {
+        console.error('Error processing audio segments:', error);
       }
     }
 
@@ -362,12 +366,16 @@ export class CmcdIntegration {
     }
 
     if (this.currentVideoQuality) {
-      const allSegments = this.player.getAvailableSegments();
-      for (const mimeType in allSegments) {
-        if (mimeType.startsWith('video/')) {
-          const segments = allSegments[mimeType][this.currentVideoQuality.id];
-          data = data.concat(this.getNextObjectAndObjectDurationCmcdData(segments, request.url));
+      try {
+        const allSegments = this.player.getAvailableSegments();
+        for (const mimeType in allSegments) {
+          if (mimeType.startsWith('video/')) {
+            const segments = allSegments[mimeType][this.currentVideoQuality.id];
+            data = data.concat(this.getNextObjectAndObjectDurationCmcdData(segments, request.url));
+          }
         }
+      } catch (error) {
+        console.error('Error processing video segments:', error);
       }
     }
 


### PR DESCRIPTION
## Description
- Issue: https://github.com/bitmovin/bitmovin-player-web-integration-cmcd/issues/6

## Problem

Currently, `player.getAvailableSegments` API is executed inside the Network API (preprocessHttpRequest) logic, but there is no error handling logic when an error occurs in this API. As a result, when an exception is thrown inside this API, the DASH manifest fails to load properly as the network API doesn't process correctly.

## Changes
Added a try-catch block around the player.getAvailableSegments() method to handle potential runtime error that specifically occur when parsing DASH manifests using the SegmentTimeline with the $number format.

## Tests
Ran the existing unit test `npm run test` and confirmed all passed.
Ran an e2e test using the DASH-IF test vector of SegmentTimeline with $number format

## Considerations
The underlying API issue itself is not yet resolved and will need further improvements. This has been reported internally (PW-20681).
